### PR TITLE
sdr_trc_fix:

### DIFF
--- a/Shaders/lilium__sdr_trc_fix.fx
+++ b/Shaders/lilium__sdr_trc_fix.fx
@@ -81,8 +81,8 @@ float3 Bt1886(
   static const float b = powLb
                        / powLw_minus_powLb;
 
-  const float3 L = pow(a * max(V + b, 0.f), gamma);
-  const float3 L_norm = (L - BT1886_TARGET_BLACKPOINT) / (BT1886_TARGET_WHITEPOINT - BT1886_TARGET_BLACKPOINT)
+  const float3 L = a * pow(max(V + b, 0.f), gamma);
+  const float3 L_norm = (L - BT1886_TARGET_BLACKPOINT) / (BT1886_TARGET_WHITEPOINT - BT1886_TARGET_BLACKPOINT);
 
   return L_norm;
 }


### PR DESCRIPTION
```
- compute normalized value so that blacks are not raised by bt1886
- apply bt1886 eotf at input signal instead of its inverse at regamma
```

Currently, raising the BT.1886 black point also raises the black luminance on regamma. Normalizing the luminance fixes this. This way, the curve will look correct when viewed on a monitor with a non-zero black level.

Also, the BT.1886 eotf can be applied to only the input signal instead, and normally re-gamma'd rather than having two separate functions.